### PR TITLE
Add `mdi-norm/macro`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,7 @@
 - [`react-broker/macros`](https://www.npmjs.com/package/react-broker): Lazy-load components using React 16.3+
 - [`rpi.macro`](https://www.npmjs.com/package/rpi.macro): Macro for [`react-precious-image`](https://github.com/stereobooster/react-precious-image)
 - [`react-hot-reload.macro`](https://www.npmjs.com/package/react-hot-reload.macro): Zero configuration Hot Module Replacement for CRAv2
+- [`mdi-norm/macro`](https://github.com/eugeneilyin/mdi-norm#with-babel-macros): Material Design system SVG icons embedding
 
 ### CSS-in-JS
 

--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@
 - [`react-broker/macros`](https://www.npmjs.com/package/react-broker): Lazy-load components using React 16.3+
 - [`rpi.macro`](https://www.npmjs.com/package/rpi.macro): Macro for [`react-precious-image`](https://github.com/stereobooster/react-precious-image)
 - [`react-hot-reload.macro`](https://www.npmjs.com/package/react-hot-reload.macro): Zero configuration Hot Module Replacement for CRAv2
-- [`mdi-norm/macro`](https://github.com/eugeneilyin/mdi-norm#with-babel-macros): Material Design system SVG icons embedding
+- [`mdi-norm/macro`](https://github.com/eugeneilyin/mdi-norm#with-babel-macros): Embed Material Design system SVG icons
 
 ### CSS-in-JS
 


### PR DESCRIPTION
I've created a lot of possible syntax usages by macro:
- embed icons as string literals
- embed icons as JSX tags
- embed icons as function call

Even more I've add even HTML lower-case JSX tags support.
Please see `mdi-norm/macro` code samples.

Also different macro import ways (as `import {}` or as `require()`) produces different import inserts.
Maybe someone will be interested in this techniques in macro coding.